### PR TITLE
Add CI builds for PRs and master merges

### DIFF
--- a/.github/workflows/merged_master.yml
+++ b/.github/workflows/merged_master.yml
@@ -1,0 +1,19 @@
+name: Master Merge Build
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'master'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Build and Test
+        run: ./mvnw -B verify

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,18 @@
+name: PR Build
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Build and Test
+        run: ./mvnw -B verify


### PR DESCRIPTION
## Summary
- add workflow to build with JDK 21 for all pull requests
- add workflow to build when pull requests merge to `master`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6849e77d6cc483319654ef28ec2e3c45