### PR TITLE
Add per-pattern READMEs with PlantUML diagrams

### DIFF
--- a/src/main/java/com/penapereira/example/constructs/abstractfactory/README.md
+++ b/src/main/java/com/penapereira/example/constructs/abstractfactory/README.md
@@ -1,0 +1,29 @@
+# Abstract Factory Pattern
+
+The abstract factory pattern provides an interface for creating families of related objects without specifying their concrete classes. This example defines two factories that each create a pair of products.
+
+## Class diagram
+```plantuml
+@startuml
+interface AbstractFactory {
+    +createProductA()
+    +createProductB()
+}
+
+interface ProductA
+interface ProductB
+
+class Factory1 implements AbstractFactory
+class Factory2 implements AbstractFactory
+
+Factory1 --> ProductA1
+Factory1 --> ProductB1
+Factory2 --> ProductA2
+Factory2 --> ProductB2
+
+class ProductA1 implements ProductA
+class ProductA2 implements ProductA
+class ProductB1 implements ProductB
+class ProductB2 implements ProductB
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/adapter/README.md
+++ b/src/main/java/com/penapereira/example/constructs/adapter/README.md
@@ -1,0 +1,21 @@
+# Adapter Pattern
+
+The adapter pattern allows incompatible interfaces to work together. It wraps an existing class with a new interface so that it can be used as another type.
+
+## Class diagram
+```plantuml
+@startuml
+interface Target {
+    +request()
+}
+class Adaptee {
+    +specificRequest()
+}
+class Adapter implements Target {
+    -adaptee : Adaptee
+    +request()
+}
+Target <|.. Adapter
+Adapter --> Adaptee
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/decorator/README.md
+++ b/src/main/java/com/penapereira/example/constructs/decorator/README.md
@@ -1,0 +1,21 @@
+# Decorator Pattern
+
+The decorator pattern attaches additional responsibilities to an object dynamically by wrapping it with decorator classes.
+
+## Class diagram
+```plantuml
+@startuml
+interface ComponentIF {
+    +operation()
+}
+class ConcreteComponent implements ComponentIF
+abstract class Decorator implements ComponentIF {
+    -component : ComponentIF
+}
+class ConcreteDecoratorA extends Decorator
+ComponentIF <|.. ConcreteComponent
+ComponentIF <|.. Decorator
+Decorator <|-- ConcreteDecoratorA
+ConcreteDecoratorA --> ComponentIF
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/factory/README.md
+++ b/src/main/java/com/penapereira/example/constructs/factory/README.md
@@ -1,0 +1,19 @@
+# Factory Pattern
+
+The factory pattern encapsulates object creation logic in a dedicated factory class. The factory decides which concrete product to instantiate.
+
+## Class diagram
+```plantuml
+@startuml
+interface Product {
+    +name()
+}
+class ConcreteProductA implements Product
+class ConcreteProductB implements Product
+class ProductFactory {
+    +createProduct(type)
+}
+ProductFactory --> ConcreteProductA
+ProductFactory --> ConcreteProductB
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/factorymethod/README.md
+++ b/src/main/java/com/penapereira/example/constructs/factorymethod/README.md
@@ -1,0 +1,17 @@
+# Factory Method Pattern
+
+The factory method pattern defines an interface for creating an object but lets subclasses decide which class to instantiate.
+
+## Class diagram
+```plantuml
+@startuml
+abstract class GenericProduct {
+    +factoryMethod()
+    +build()
+}
+class ConcreteProductA extends GenericProduct
+class ConcreteProductB extends GenericProduct
+GenericProduct <|-- ConcreteProductA
+GenericProduct <|-- ConcreteProductB
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/observer/README.md
+++ b/src/main/java/com/penapereira/example/constructs/observer/README.md
@@ -1,0 +1,23 @@
+# Observer Pattern
+
+The observer pattern defines a one-to-many dependency so that when one object changes state, its dependents are notified automatically.
+
+## Class diagram
+```plantuml
+@startuml
+interface ObservableInterface {
+    +getSupport()
+    +addPropertyChangeListener(l)
+    +removePropertyChangeListener(l)
+}
+abstract class ObservableAbstract implements ObservableInterface
+class Observable extends ObservableAbstract {
+    +doSomethingWith(n)
+}
+class Observer implements PropertyChangeListener {
+    +propertyChange(e)
+}
+ObservableAbstract <|-- Observable
+Observable --> Observer : notifies
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/singleton/README.md
+++ b/src/main/java/com/penapereira/example/constructs/singleton/README.md
@@ -1,0 +1,15 @@
+# Singleton Pattern
+
+The singleton pattern ensures a class has only one instance while providing a global point of access to it.
+
+## Class diagram
+```plantuml
+@startuml
+class Singleton {
+    -uniqueInstance : Singleton
+    -Singleton()
+    +instance() : Singleton
+    +doSomething()
+}
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/strategy/README.md
+++ b/src/main/java/com/penapereira/example/constructs/strategy/README.md
@@ -1,0 +1,22 @@
+# Strategy Pattern
+
+The strategy pattern defines a family of algorithms, encapsulates each one, and makes them interchangeable at runtime.
+
+## Class diagram
+```plantuml
+@startuml
+interface Strategy {
+    +executeAlgorithm()
+}
+class StrategyImpl1 implements Strategy
+class StrategyImpl2 implements Strategy
+class Context {
+    -strategy : Strategy
+    +operation()
+    +setStrategy(Strategy)
+}
+Strategy <|.. StrategyImpl1
+Strategy <|.. StrategyImpl2
+Context --> Strategy
+@enduml
+```

--- a/src/main/java/com/penapereira/example/constructs/templatemethod/README.md
+++ b/src/main/java/com/penapereira/example/constructs/templatemethod/README.md
@@ -1,0 +1,18 @@
+# Template Method Pattern
+
+The template method pattern defines the skeleton of an algorithm in a base class and lets subclasses override specific steps.
+
+## Class diagram
+```plantuml
+@startuml
+abstract class AbstractClass {
+    +templateMethod()
+    #stepOne()
+    #stepTwo()
+}
+class ConcreteClassA extends AbstractClass
+class ConcreteClassB extends AbstractClass
+AbstractClass <|-- ConcreteClassA
+AbstractClass <|-- ConcreteClassB
+@enduml
+```


### PR DESCRIPTION
## Summary
- document every design pattern directory
- include PlantUML class diagrams for each pattern

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_685020fd809c8331bc52b9fd089f663e